### PR TITLE
feat: display stack creation summary in github action summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A reusable GitHub Action that automates the deployment of AWS CloudFormation sta
 - ✅ **Template Validation**: Pre-deployment template validation to catch errors early
 - 🚫 **No Rollback on Failure**: Disabled rollback allows for easier debugging of failed deployments
 - 🔄 **Robust Tag Processing**: Fallback mechanisms ensure tags are processed even with temp file issues
+- 📊 **GitHub Actions Step Summary**: Automatic generation of deployment summary in GitHub Actions UI
 - 📋 **Detailed Output**: Stack outputs and deployment summaries for troubleshooting
 
 ---
@@ -432,6 +433,57 @@ Stack Outputs:
 |  BucketName         |  my-app-bucket-abc123           |  Name of the created S3 bucket  |
 |  BucketArn          |  arn:aws:s3:::my-app-bucket-abc123 |  ARN of the created S3 bucket   |
 ```
+
+---
+
+## GitHub Actions Step Summary
+
+The action automatically generates a comprehensive step summary that appears in the GitHub Actions UI, providing a quick overview of the deployment without needing to dig through logs.
+
+### Summary Format
+
+The step summary includes:
+
+```markdown
+# CloudFormation Stack Creation Report
+
+## Summary
+✅ **Stack creation success**
+
+## Details
+| Property | Value |
+|----------|-------|
+| Stack Name | `my-application-stack` |
+| Final Status | `CREATE_COMPLETE` |
+| Operation Result | ✅ success |
+| Duration | 45s |
+
+## Timing Information
+- **Start Time:** 2025-08-08 18:52:13 UTC
+- **End Time:** 2025-08-08 18:52:58 UTC
+- **Total Duration:** 45s
+
+## Result
+The CloudFormation stack has been successfully created.
+```
+
+### Summary Features
+
+- **Visual Status Indicators**: Clear success/failure indicators with emojis
+- **Deployment Details**: Stack name, final status, and operation result
+- **Accurate Timing**: Real deployment start and end times from CloudFormation events
+- **Duration Calculation**: Precise duration based on actual stack events
+- **Result Summary**: Clear description of the deployment outcome
+
+### Status Indicators
+
+| Status | Indicator | Description |
+|--------|-----------|-------------|
+| Success | ✅ success | Stack created/updated successfully |
+| Warning | ⚠️ warning | Stack completed but in unexpected state |
+| Failed | ❌ failed | Stack deployment failed |
+
+The step summary is automatically generated for every deployment and provides immediate visibility into the deployment status directly in the GitHub Actions interface.
 
 ---
 

--- a/action.yaml
+++ b/action.yaml
@@ -507,63 +507,95 @@ runs:
         
         # Get stack information
         STACK_STATUS=$(aws cloudformation describe-stacks --stack-name "$DEPLOYMENT_STACK_NAME" --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "UNKNOWN")
-        STACK_CREATION_TIME=$(aws cloudformation describe-stacks --stack-name "$DEPLOYMENT_STACK_NAME" --query "Stacks[0].CreationTime" --output text 2>/dev/null || echo "")
-        STACK_UPDATE_TIME=$(aws cloudformation describe-stacks --stack-name "$DEPLOYMENT_STACK_NAME" --query "Stacks[0].LastUpdatedTime" --output text 2>/dev/null || echo "")
         
-        # Determine start and end times
-        if [ "$STACK_UPDATE_TIME" != "" ] && [ "$STACK_UPDATE_TIME" != "None" ]; then
-          START_TIME="$STACK_UPDATE_TIME"
+        # Get stack events for timing calculation - use simpler approach
+        echo "Retrieving stack events for timing calculation..."
+        
+        # Get the first CREATE_IN_PROGRESS or UPDATE_IN_PROGRESS event for the stack (start time)
+        START_EVENT=$(aws cloudformation describe-stack-events \
+          --stack-name "$DEPLOYMENT_STACK_NAME" \
+          --query "StackEvents[?ResourceType=='AWS::CloudFormation::Stack' && (ResourceStatus=='CREATE_IN_PROGRESS' || ResourceStatus=='UPDATE_IN_PROGRESS')] | [-1]" \
+          --output json 2>/dev/null)
+        
+        # Get the most recent CREATE_COMPLETE, UPDATE_COMPLETE, or final status event for the stack (end time)
+        END_EVENT=$(aws cloudformation describe-stack-events \
+          --stack-name "$DEPLOYMENT_STACK_NAME" \
+          --query "StackEvents[?ResourceType=='AWS::CloudFormation::Stack' && (ResourceStatus=='CREATE_COMPLETE' || ResourceStatus=='UPDATE_COMPLETE' || ResourceStatus=='CREATE_FAILED' || ResourceStatus=='UPDATE_FAILED')] | [0]" \
+          --output json 2>/dev/null)
+        
+        # Extract timestamps using jq
+        if [ "$START_EVENT" != "null" ] && [ "$START_EVENT" != "" ]; then
+          START_TIMESTAMP=$(echo "$START_EVENT" | jq -r '.Timestamp // empty' 2>/dev/null)
         else
-          START_TIME="$STACK_CREATION_TIME"
+          START_TIMESTAMP=""
         fi
         
-        # Get current time as end time
-        END_TIME=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+        if [ "$END_EVENT" != "null" ] && [ "$END_EVENT" != "" ]; then
+          END_TIMESTAMP=$(echo "$END_EVENT" | jq -r '.Timestamp // empty' 2>/dev/null)
+        else
+          END_TIMESTAMP=""
+        fi
         
-        # Calculate duration (simplified - using stack events for more accurate timing)
-        STACK_EVENTS=$(aws cloudformation describe-stack-events --stack-name "$DEPLOYMENT_STACK_NAME" --query "StackEvents[?ResourceType=='AWS::CloudFormation::Stack'].[Timestamp]" --output text 2>/dev/null | head -2)
-        
-        # Get the most recent stack event timestamp for more accurate timing
-        LATEST_EVENT_TIME=$(aws cloudformation describe-stack-events --stack-name "$DEPLOYMENT_STACK_NAME" --query "StackEvents[0].Timestamp" --output text 2>/dev/null || echo "")
-        OLDEST_RELEVANT_EVENT_TIME=$(aws cloudformation describe-stack-events --stack-name "$DEPLOYMENT_STACK_NAME" --query "StackEvents[?ResourceType=='AWS::CloudFormation::Stack' && (ResourceStatus=='CREATE_IN_PROGRESS' || ResourceStatus=='UPDATE_IN_PROGRESS')][-1].Timestamp" --output text 2>/dev/null || echo "")
-        
-        # Calculate duration in seconds (simplified approach)
-        if [ "$LATEST_EVENT_TIME" != "" ] && [ "$OLDEST_RELEVANT_EVENT_TIME" != "" ]; then
-          # Convert timestamps to epoch for calculation
-          END_EPOCH=$(date -d "$LATEST_EVENT_TIME" +%s 2>/dev/null || date +%s)
-          START_EPOCH=$(date -d "$OLDEST_RELEVANT_EVENT_TIME" +%s 2>/dev/null || date +%s)
-          DURATION_SECONDS=$((END_EPOCH - START_EPOCH))
-          
-          # Format duration
-          if [ $DURATION_SECONDS -lt 60 ]; then
-            DURATION="${DURATION_SECONDS}s"
-          elif [ $DURATION_SECONDS -lt 3600 ]; then
-            DURATION_MINUTES=$((DURATION_SECONDS / 60))
-            DURATION_REMAINING=$((DURATION_SECONDS % 60))
-            DURATION="${DURATION_MINUTES}m ${DURATION_REMAINING}s"
+        # Calculate duration and format timestamps
+        if [ -n "$START_TIMESTAMP" ] && [ -n "$END_TIMESTAMP" ]; then
+          # Convert ISO timestamps to epoch (works on both Linux and macOS)
+          if command -v gdate >/dev/null 2>&1; then
+            # macOS with GNU coreutils
+            START_EPOCH=$(gdate -d "$START_TIMESTAMP" +%s 2>/dev/null)
+            END_EPOCH=$(gdate -d "$END_TIMESTAMP" +%s 2>/dev/null)
+            FORMATTED_START_TIME=$(gdate -d "$START_TIMESTAMP" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null)
+            FORMATTED_END_TIME=$(gdate -d "$END_TIMESTAMP" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null)
           else
-            DURATION_HOURS=$((DURATION_SECONDS / 3600))
-            DURATION_REMAINING=$((DURATION_SECONDS % 3600))
-            DURATION_MINUTES=$((DURATION_REMAINING / 60))
-            DURATION_SECONDS_FINAL=$((DURATION_REMAINING % 60))
-            DURATION="${DURATION_HOURS}h ${DURATION_MINUTES}m ${DURATION_SECONDS_FINAL}s"
+            # Linux or macOS with BSD date
+            START_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${START_TIMESTAMP%.*}" +%s 2>/dev/null || date -d "$START_TIMESTAMP" +%s 2>/dev/null)
+            END_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${END_TIMESTAMP%.*}" +%s 2>/dev/null || date -d "$END_TIMESTAMP" +%s 2>/dev/null)
+            FORMATTED_START_TIME=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${START_TIMESTAMP%.*}" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null || date -d "$START_TIMESTAMP" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null)
+            FORMATTED_END_TIME=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${END_TIMESTAMP%.*}" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null || date -d "$END_TIMESTAMP" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null)
+          fi
+          
+          # Calculate duration if we have valid epochs
+          if [ -n "$START_EPOCH" ] && [ -n "$END_EPOCH" ] && [ "$START_EPOCH" -gt 0 ] && [ "$END_EPOCH" -gt 0 ]; then
+            DURATION_SECONDS=$((END_EPOCH - START_EPOCH))
+            
+            # Format duration
+            if [ $DURATION_SECONDS -lt 60 ]; then
+              DURATION="${DURATION_SECONDS}s"
+            elif [ $DURATION_SECONDS -lt 3600 ]; then
+              DURATION_MINUTES=$((DURATION_SECONDS / 60))
+              DURATION_REMAINING=$((DURATION_SECONDS % 60))
+              DURATION="${DURATION_MINUTES}m ${DURATION_REMAINING}s"
+            else
+              DURATION_HOURS=$((DURATION_SECONDS / 3600))
+              DURATION_REMAINING=$((DURATION_SECONDS % 3600))
+              DURATION_MINUTES=$((DURATION_REMAINING / 60))
+              DURATION_SECONDS_FINAL=$((DURATION_REMAINING % 60))
+              DURATION="${DURATION_HOURS}h ${DURATION_MINUTES}m ${DURATION_SECONDS_FINAL}s"
+            fi
+          else
+            DURATION="Unknown"
+            FORMATTED_START_TIME="Unknown"
+            FORMATTED_END_TIME="Unknown"
           fi
         else
           DURATION="Unknown"
-          DURATION_SECONDS=0
-        fi
-        
-        # Format timestamps for display
-        if [ "$OLDEST_RELEVANT_EVENT_TIME" != "" ]; then
-          FORMATTED_START_TIME=$(date -d "$OLDEST_RELEVANT_EVENT_TIME" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null || echo "Unknown")
-        else
           FORMATTED_START_TIME="Unknown"
+          FORMATTED_END_TIME="Unknown"
         fi
         
-        if [ "$LATEST_EVENT_TIME" != "" ]; then
-          FORMATTED_END_TIME=$(date -d "$LATEST_EVENT_TIME" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null || echo "Unknown")
-        else
-          FORMATTED_END_TIME="Unknown"
+        # Fallback: if we still don't have timing info, try to get basic stack info
+        if [ "$FORMATTED_START_TIME" = "Unknown" ]; then
+          STACK_CREATION_TIME=$(aws cloudformation describe-stacks --stack-name "$DEPLOYMENT_STACK_NAME" --query "Stacks[0].CreationTime" --output text 2>/dev/null)
+          if [ -n "$STACK_CREATION_TIME" ] && [ "$STACK_CREATION_TIME" != "None" ]; then
+            if command -v gdate >/dev/null 2>&1; then
+              FORMATTED_START_TIME=$(gdate -d "$STACK_CREATION_TIME" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null || echo "Unknown")
+            else
+              FORMATTED_START_TIME=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${STACK_CREATION_TIME%.*}" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null || date -d "$STACK_CREATION_TIME" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null || echo "Unknown")
+            fi
+          fi
+        fi
+        
+        if [ "$FORMATTED_END_TIME" = "Unknown" ]; then
+          FORMATTED_END_TIME=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
         fi
         
         # Determine success/failure status

--- a/action.yaml
+++ b/action.yaml
@@ -456,7 +456,7 @@ runs:
         echo "Recent Stack Events:"
         aws cloudformation describe-stack-events \
           --stack-name "$DEPLOYMENT_STACK_NAME" \
-          --query "StackEvents[:10].[Timestamp,LogicalResourceId,ResourceType,ResourceStatus,ResourceStatusReason]" \
+          --query "StackEvents[:10].[Timestamp,LogicalResourceId,ResourceType,ResourceStatus,ResourceStatusReason || '-']" \
           --output table || echo "⚠️ Unable to retrieve stack events"
         
         # Display stack outputs in a clean, readable format
@@ -494,6 +494,123 @@ runs:
             exit 1
             ;;
         esac
+
+    - name: Generate GitHub Actions Step Summary
+      shell: bash
+      run: |
+        # Load deployment info from previous steps
+        DEPLOYMENT_STACK_NAME=$(cat /tmp/stack-name)
+        DEPLOYMENT_TEMPLATE_PATH=$(cat /tmp/template-path)
+        PARAMETER_OVERRIDES=$(cat /tmp/parameter-overrides)
+        TAG_OVERRIDES=$(cat /tmp/tag-overrides | tr -d '\n\r')
+        DEPLOY_EXIT_CODE=$(cat /tmp/deploy-exit-code)
+        
+        # Get stack information
+        STACK_STATUS=$(aws cloudformation describe-stacks --stack-name "$DEPLOYMENT_STACK_NAME" --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "UNKNOWN")
+        STACK_CREATION_TIME=$(aws cloudformation describe-stacks --stack-name "$DEPLOYMENT_STACK_NAME" --query "Stacks[0].CreationTime" --output text 2>/dev/null || echo "")
+        STACK_UPDATE_TIME=$(aws cloudformation describe-stacks --stack-name "$DEPLOYMENT_STACK_NAME" --query "Stacks[0].LastUpdatedTime" --output text 2>/dev/null || echo "")
+        
+        # Determine start and end times
+        if [ "$STACK_UPDATE_TIME" != "" ] && [ "$STACK_UPDATE_TIME" != "None" ]; then
+          START_TIME="$STACK_UPDATE_TIME"
+        else
+          START_TIME="$STACK_CREATION_TIME"
+        fi
+        
+        # Get current time as end time
+        END_TIME=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+        
+        # Calculate duration (simplified - using stack events for more accurate timing)
+        STACK_EVENTS=$(aws cloudformation describe-stack-events --stack-name "$DEPLOYMENT_STACK_NAME" --query "StackEvents[?ResourceType=='AWS::CloudFormation::Stack'].[Timestamp]" --output text 2>/dev/null | head -2)
+        
+        # Get the most recent stack event timestamp for more accurate timing
+        LATEST_EVENT_TIME=$(aws cloudformation describe-stack-events --stack-name "$DEPLOYMENT_STACK_NAME" --query "StackEvents[0].Timestamp" --output text 2>/dev/null || echo "")
+        OLDEST_RELEVANT_EVENT_TIME=$(aws cloudformation describe-stack-events --stack-name "$DEPLOYMENT_STACK_NAME" --query "StackEvents[?ResourceType=='AWS::CloudFormation::Stack' && (ResourceStatus=='CREATE_IN_PROGRESS' || ResourceStatus=='UPDATE_IN_PROGRESS')][-1].Timestamp" --output text 2>/dev/null || echo "")
+        
+        # Calculate duration in seconds (simplified approach)
+        if [ "$LATEST_EVENT_TIME" != "" ] && [ "$OLDEST_RELEVANT_EVENT_TIME" != "" ]; then
+          # Convert timestamps to epoch for calculation
+          END_EPOCH=$(date -d "$LATEST_EVENT_TIME" +%s 2>/dev/null || date +%s)
+          START_EPOCH=$(date -d "$OLDEST_RELEVANT_EVENT_TIME" +%s 2>/dev/null || date +%s)
+          DURATION_SECONDS=$((END_EPOCH - START_EPOCH))
+          
+          # Format duration
+          if [ $DURATION_SECONDS -lt 60 ]; then
+            DURATION="${DURATION_SECONDS}s"
+          elif [ $DURATION_SECONDS -lt 3600 ]; then
+            DURATION_MINUTES=$((DURATION_SECONDS / 60))
+            DURATION_REMAINING=$((DURATION_SECONDS % 60))
+            DURATION="${DURATION_MINUTES}m ${DURATION_REMAINING}s"
+          else
+            DURATION_HOURS=$((DURATION_SECONDS / 3600))
+            DURATION_REMAINING=$((DURATION_SECONDS % 3600))
+            DURATION_MINUTES=$((DURATION_REMAINING / 60))
+            DURATION_SECONDS_FINAL=$((DURATION_REMAINING % 60))
+            DURATION="${DURATION_HOURS}h ${DURATION_MINUTES}m ${DURATION_SECONDS_FINAL}s"
+          fi
+        else
+          DURATION="Unknown"
+          DURATION_SECONDS=0
+        fi
+        
+        # Format timestamps for display
+        if [ "$OLDEST_RELEVANT_EVENT_TIME" != "" ]; then
+          FORMATTED_START_TIME=$(date -d "$OLDEST_RELEVANT_EVENT_TIME" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null || echo "Unknown")
+        else
+          FORMATTED_START_TIME="Unknown"
+        fi
+        
+        if [ "$LATEST_EVENT_TIME" != "" ]; then
+          FORMATTED_END_TIME=$(date -d "$LATEST_EVENT_TIME" -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null || echo "Unknown")
+        else
+          FORMATTED_END_TIME="Unknown"
+        fi
+        
+        # Determine success/failure status
+        if [ $DEPLOY_EXIT_CODE -eq 0 ]; then
+          case "$STACK_STATUS" in
+            "CREATE_COMPLETE"|"UPDATE_COMPLETE"|"UPDATE_COMPLETE_CLEANUP_IN_PROGRESS")
+              OPERATION_RESULT="✅ success"
+              SUMMARY_STATUS="✅ **Stack creation success**"
+              RESULT_MESSAGE="The CloudFormation stack has been successfully created."
+              ;;
+            *)
+              OPERATION_RESULT="⚠️ warning"
+              SUMMARY_STATUS="⚠️ **Stack creation completed with warnings**"
+              RESULT_MESSAGE="The CloudFormation stack deployment completed but is in state: $STACK_STATUS"
+              ;;
+          esac
+        else
+          OPERATION_RESULT="❌ failed"
+          SUMMARY_STATUS="❌ **Stack creation failed**"
+          RESULT_MESSAGE="The CloudFormation stack deployment failed with exit code: $DEPLOY_EXIT_CODE"
+        fi
+        
+        # Generate the GitHub Actions Step Summary
+        cat >> $GITHUB_STEP_SUMMARY << EOF
+        # CloudFormation Stack Creation Report
+        
+        ## Summary
+        $SUMMARY_STATUS
+        
+        ## Details
+        | Property | Value |
+        |----------|-------|
+        | Stack Name | \`$DEPLOYMENT_STACK_NAME\` |
+        | Final Status | \`$STACK_STATUS\` |
+        | Operation Result | $OPERATION_RESULT |
+        | Duration | $DURATION |
+        
+        ## Timing Information
+        - **Start Time:** $FORMATTED_START_TIME
+        - **End Time:** $FORMATTED_END_TIME
+        - **Total Duration:** $DURATION
+        
+        ## Result
+        $RESULT_MESSAGE
+        EOF
+        
+        echo "✅ GitHub Actions Step Summary generated successfully"
 
     - name: Display Final Results and Stack Information
       shell: bash


### PR DESCRIPTION
This pull request introduces a new feature that automatically generates a comprehensive deployment summary in the GitHub Actions UI after each AWS CloudFormation deployment. This summary provides immediate, clear feedback on the deployment status, including success/failure indicators, stack details, and precise timing information. In addition, there are minor improvements for robustness in stack event processing.

**GitHub Actions Step Summary Feature:**

* Added a new step in `action.yaml` to generate a GitHub Actions step summary after deployment, displaying deployment outcome, stack status, timing, and duration using clear visual indicators. The summary is formatted in markdown for easy readability in the Actions UI.
* Updated the `README.md` to document the new step summary feature, including sample output, summary features, and status indicator descriptions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R439-R489)

**Stack Event Processing Improvements:**

* Improved the AWS CLI query in `action.yaml` to provide a default value (`'-'`) for missing `ResourceStatusReason` fields when displaying recent stack events, making the output more robust.